### PR TITLE
Fix fit_all_parallel only running 8 workers at once.

### DIFF
--- a/velocity/tools/fit.py
+++ b/velocity/tools/fit.py
@@ -79,7 +79,7 @@ def fit_all_parallel(unspliced, spliced, n=100, n_cores=None, n_parts=None, fit_
             out.append(fit(p[0], p[1], n, fit_scaling, fit_kappa))
         return out
 
-    result = Parallel(n_jobs=8)(delayed(fit_helper)(pars[i]) for i in output)
+    result = Parallel(n_jobs=n_cores)(delayed(fit_helper)(pars[i]) for i in output)
 
     # format result
     r = []


### PR DESCRIPTION
Before, a hard-coded 8 made this only run on 8 cores. With this change, n_cores is respected.