### PR TITLE
Fix deprecated builtins and argument

### DIFF
--- a/velocity/project/nystroem.py
+++ b/velocity/project/nystroem.py
@@ -57,7 +57,7 @@ def nystroem_project(adata, basis="umap", n_neighbors=100,
 
     print("Projecting velocities using Nyström approach.")
 
-    NN = cKDTree(X_current).query(x=X_future, k=n_neighbors, n_jobs=1)[1]
+    NN = cKDTree(X_current).query(x=X_future, k=n_neighbors)[1]
     # get row normalisation factors
     P = d2p_NN(pairwise_distances(X_current, metric="euclidean"), NN, row_norm=False)
     D = np.diag(1 / np.sqrt(np.sum(P, axis=1)))

--- a/velocity/project/pca.py
+++ b/velocity/project/pca.py
@@ -9,8 +9,8 @@ def pca_project(adata, use_raw=False, variance_mean_scale=True, random_state=0, 
         return
     velocity = adata.layers["velocity"]
     spliced = adata.layers["spliced" if use_raw else "Ms"]
-    sub = np.any(np.isnan(np.array(velocity.astype(np.float))), axis=1)  # velocities need to be non-null for PCA
-    sub &= np.any(np.isnan(np.array(spliced.astype(np.float))), axis=1)
+    sub = np.any(np.isnan(np.array(velocity.astype(float))), axis=1)  # velocities need to be non-null for PCA
+    sub &= np.any(np.isnan(np.array(spliced.astype(float))), axis=1)
     if np.sum(sub) > 0:
         print("Warning: " + str(np.sum(sub)) + " genes excluded from PCA because the velocities are np.nan. This "
                                                "usually means that the kinetics are not recovered for those genes.")

--- a/velocity/tools/prior.py
+++ b/velocity/tools/prior.py
@@ -25,7 +25,7 @@ def set_prior_state(adata, connections_dict, clusterkey="clusters"):
 
     """
     
-    k_df = pd.DataFrame(np.zeros(adata.layers["Mu"].shape, dtype=np.int), columns=adata.var_names)
+    k_df = pd.DataFrame(np.zeros(adata.layers["Mu"].shape, dtype=int), columns=adata.var_names)
     
     for idx, gene in enumerate(adata.var_names):
         counts_df = pd.DataFrame({'Ms':adata[:,gene].layers["Ms"].flatten(),


### PR DESCRIPTION
- Replace `np.float`/`np.int` with built-in `float`/int` which was deprecated in numpy 1.20
- Remove deprecated argument of `scipy.spatial._ckdtree.cKDTree.query`
